### PR TITLE
Initialize a variable and avoid a potential NULL dereference.

### DIFF
--- a/iotc-generic-c-sdk/curl-http-impl/src/iotc_http_request.c
+++ b/iotc-generic-c-sdk/curl-http-impl/src/iotc_http_request.c
@@ -38,10 +38,11 @@ int iotconnect_https_request(
         const char *send_str
 ) {
     CURL *curl;
-    CURLcode res;
+    CURLcode res = (!CURLE_OK); /* FIXME there's probably a better value to initialize this too */
 
     if (NULL == response) {
         fprintf(stderr, "iotconnect_https_request() requires a valid IotConnectHttpResponse pointer.");
+        return res;
     }
     response->data = NULL;
 


### PR DESCRIPTION
Untested - no QA.

Need to initialize the variable -- but not clear to me what value should be used.
Added an early exit to avoid a possible NULL dereference.