### PR TITLE
Iotc generic c sdk 2.1 review

### DIFF
--- a/iotc-generic-c-sdk/azure-sdk-impl/src/azure_sdk_client.c
+++ b/iotc-generic-c-sdk/azure-sdk-impl/src/azure_sdk_client.c
@@ -185,7 +185,7 @@ int iotc_device_client_send_message_with_mt(const char* message, int mt )
 {
     if (connection_status != IOTC_CS_MQTT_CONNECTED) {
         fprintf(stderr, "Error: Failed to send message: %s. Client is not connected.", message);
-        return -1;
+        return -3;
     }
     IOTHUB_MESSAGE_HANDLE message_handle;
     //IOTHUB_MESSAGE_HANDLE message_handle = IoTHubMessage_CreateFromString(message);
@@ -223,7 +223,7 @@ int iotc_device_client_send_message_with_mt(const char* message, int mt )
     if (is_message_confirmed) {
         is_message_confirmed = true;
         return 0;
-    }else {
+    } else {
         fprintf(stderr, "Unable to obtain message confirmation for message %s", message);
         return -1;
     }
@@ -334,6 +334,7 @@ IOTHUB_DEVICE_CLIENT_LL_HANDLE provision_with_dps(const char* id_scope, const ch
 }
 
 int iotc_device_client_init(IotConnectDeviceClientConfig *c) {
+    
     meta_cd = c->sr->meta.cd;
     meta_v = c->sr->meta.v;
     // Used to initialize IoTHub SDK subsystem
@@ -380,9 +381,7 @@ int iotc_device_client_init(IotConnectDeviceClientConfig *c) {
             sprintf(connection_string_buffer, IOTC_CONNECTION_STRING_FORMAT_X509,
                     c->sr->broker.host,
                     c->sr->broker.client_id
-            );
-
-            
+            );        
             break;
         case IOTC_AT_TPM:
             break;
@@ -405,8 +404,6 @@ int iotc_device_client_init(IotConnectDeviceClientConfig *c) {
                     c->sr->broker.client_id,
                     c->auth->data.symmetric_key
             );
-
-            printf("Connection string %s\n", connection_string_buffer);
             break;
         default:
             fprintf(stderr, "Unknown authentication type\n");

--- a/iotc-generic-c-sdk/azure-sdk-impl/src/azure_sdk_client.c
+++ b/iotc-generic-c-sdk/azure-sdk-impl/src/azure_sdk_client.c
@@ -79,7 +79,7 @@ static char *file_to_string(const char *filename) {
         fclose(f);
     }
 
-    if (0 == num_read || num_read != length) {
+    if (0 == num_read || num_read != (size_t) length) {
         fprintf(stderr, "Unable to read device PEM info at %s\n", filename);
         free(buffer);
         return NULL;
@@ -202,7 +202,7 @@ int iotc_device_client_send_message_with_mt(const char *message, int mt )
         Map_AddOrUpdate(propMap, "mt", propText3);//
 
         if (IoTHubDeviceClient_LL_SendEventAsync(device_ll_handle, message_handle, send_confirm_callback, (void*)message_handle) !=
-            IOTHUB_MESSAGE_OK) {
+            IOTHUB_CLIENT_OK) {
             fprintf(stderr, "Error: Failed to send message: %s", message);
         }else{
             (void)printf("IoTHubModuleClient_LL_SendEventAsync accepted message for transmission to IoT Hub.\r\n");
@@ -237,6 +237,8 @@ void iotc_device_client_receive(void) {
 }
 
 int iotc_device_client_send_message_qos(const char *message, int qos) {
+    (void) qos;
+
     fprintf(stderr,
             "WARNING: QOS level and retry policy is currently not supported by the Azure Device SDK implementation");
     return iotc_device_client_send_message(message);

--- a/iotc-generic-c-sdk/azure-sdk-impl/src/azure_sdk_client.c
+++ b/iotc-generic-c-sdk/azure-sdk-impl/src/azure_sdk_client.c
@@ -44,8 +44,8 @@ static char propText3[1024];
 
 typedef struct DPS_CLIENT_INFO_TAG
 {
-    char* iothub_uri;
-    char* device_id;
+    char *iothub_uri;
+    char *device_id;
     int registration_complete;
 } DPS_CLIENT_INFO;
 DPS_CLIENT_INFO dps_data = {0};
@@ -59,7 +59,7 @@ static IotConnectC2dCallback c2d_msg_cb = NULL; // callback for inbound messages
 static IotConnectStatusCallback status_cb = NULL; // callback for connection connection_status
 static IotConnectConnectionStatus connection_status = IOTC_CS_UNDEFINED;
 
-const char* meta_cd;
+const char *meta_cd;
 double meta_v;
 
 // file_to_string() credit: https://stackoverflow.com/questions/174531/how-to-read-the-content-of-a-file-to-a-string-in-c
@@ -173,15 +173,15 @@ bool iotc_device_client_is_connected(void) {
     return (connection_status == IOTC_CS_MQTT_CONNECTED);
 }
 
-int iotc_device_client_send_ack_message(const char* message) {
+int iotc_device_client_send_ack_message(const char *message) {
     return iotc_device_client_send_message_with_mt(message, 6); 
 }
 
-int iotc_device_client_send_message(const char* message) {
+int iotc_device_client_send_message(const char *message) {
     return iotc_device_client_send_message_with_mt(message, 0);
 }
 
-int iotc_device_client_send_message_with_mt(const char* message, int mt )
+int iotc_device_client_send_message_with_mt(const char *message, int mt )
 {
     if (connection_status != IOTC_CS_MQTT_CONNECTED) {
         fprintf(stderr, "Error: Failed to send message: %s. Client is not connected.", message);

--- a/iotc-generic-c-sdk/include/iotc_device_client.h
+++ b/iotc-generic-c-sdk/include/iotc_device_client.h
@@ -51,8 +51,6 @@ int iotc_device_client_send_ack_message(const char* message);
 // sends ack message with specified qos
 int iotc_device_client_send_ack_message_qos(const char* message, int qos);
 
-
-
 void iotc_device_client_receive(void);
 
 // Returns the TPM registration ID from the TPM chip.

--- a/iotc-generic-c-sdk/include/iotc_device_client.h
+++ b/iotc-generic-c-sdk/include/iotc_device_client.h
@@ -43,6 +43,16 @@ int iotc_device_client_send_message(const char *message);
 // sends message with specified qos
 int iotc_device_client_send_message_qos(const char *message, int qos);
 
+int iotc_device_client_send_message_with_mt(const char* message, int mt);
+
+// sends ack message with QOS 1
+int iotc_device_client_send_ack_message(const char* message);
+
+// sends ack message with specified qos
+int iotc_device_client_send_ack_message_qos(const char* message, int qos);
+
+
+
 void iotc_device_client_receive(void);
 
 // Returns the TPM registration ID from the TPM chip.

--- a/iotc-generic-c-sdk/include/iotc_device_client.h
+++ b/iotc-generic-c-sdk/include/iotc_device_client.h
@@ -43,13 +43,13 @@ int iotc_device_client_send_message(const char *message);
 // sends message with specified qos
 int iotc_device_client_send_message_qos(const char *message, int qos);
 
-int iotc_device_client_send_message_with_mt(const char* message, int mt);
+int iotc_device_client_send_message_with_mt(const char *message, int mt);
 
 // sends ack message with QOS 1
-int iotc_device_client_send_ack_message(const char* message);
+int iotc_device_client_send_ack_message(const char *message);
 
 // sends ack message with specified qos
-int iotc_device_client_send_ack_message_qos(const char* message, int qos);
+int iotc_device_client_send_ack_message_qos(const char *message, int qos);
 
 void iotc_device_client_receive(void);
 

--- a/iotc-generic-c-sdk/include/iotconnect.h
+++ b/iotc-generic-c-sdk/include/iotconnect.h
@@ -82,7 +82,7 @@ void iotconnect_sdk_receive(void);
 // data is a null-terminated string
 int iotconnect_sdk_send_packet(const char *data);
 
-int iotconnect_sdk_send_ack_packet(const char* data);
+int iotconnect_sdk_send_ack_packet(const char *data);
 
 void iotconnect_sdk_disconnect(void);
 

--- a/iotc-generic-c-sdk/include/iotconnect.h
+++ b/iotc-generic-c-sdk/include/iotconnect.h
@@ -58,7 +58,6 @@ typedef struct {
     char *env;    // Settings -> Key Vault -> CPID.
     char *cpid;   // Settings -> Key Vault -> Evnironment.
     char *duid;   // Name of the device.
-    char* sid;
     int qos; // QOS for outbound messages. Default 1.
     IotConnectAuthInfo auth_info;
     IotclOtaCallback ota_cb; // callback for OTA events.

--- a/iotc-generic-c-sdk/include/iotconnect.h
+++ b/iotc-generic-c-sdk/include/iotconnect.h
@@ -58,6 +58,7 @@ typedef struct {
     char *env;    // Settings -> Key Vault -> CPID.
     char *cpid;   // Settings -> Key Vault -> Evnironment.
     char *duid;   // Name of the device.
+    char* sid;
     int qos; // QOS for outbound messages. Default 1.
     IotConnectAuthInfo auth_info;
     IotclOtaCallback ota_cb; // callback for OTA events.
@@ -81,6 +82,8 @@ void iotconnect_sdk_receive(void);
 // blocks until sent and returns 0 if successful.
 // data is a null-terminated string
 int iotconnect_sdk_send_packet(const char *data);
+
+int iotconnect_sdk_send_ack_packet(const char* data);
 
 void iotconnect_sdk_disconnect(void);
 

--- a/iotc-generic-c-sdk/paho-c-impl/src/iotc_paho_client.c
+++ b/iotc-generic-c-sdk/paho-c-impl/src/iotc_paho_client.c
@@ -12,7 +12,7 @@
 static bool is_initialized = false;
 static MQTTClient client = NULL;
 static char *publish_topic;
-static char* ack_topic;
+static char *ack_topic;
 static IotConnectC2dCallback c2d_msg_cb = NULL; // callback for inbound messages
 static IotConnectStatusCallback status_cb = NULL; // callback for connection status
 
@@ -90,7 +90,7 @@ int iotc_device_client_send_message(const char *message) {
     return iotc_device_client_send_message_qos(message, 1);
 }
 
-int iotc_device_client_send_ack_message_qos(const char* message, int qos) {
+int iotc_device_client_send_ack_message_qos(const char *message, int qos) {
     MQTTClient_message pubmsg = MQTTClient_message_initializer;
     MQTTClient_deliveryToken token;
     int rc;
@@ -108,7 +108,7 @@ int iotc_device_client_send_ack_message_qos(const char* message, int qos) {
     return rc;
 }
 
-int iotc_device_client_send_ack_message(const char* message) {
+int iotc_device_client_send_ack_message(const char *message) {
     return iotc_device_client_send_ack_message_qos(message, 0); //change it to 1
 }
 

--- a/iotc-generic-c-sdk/paho-c-impl/src/iotc_paho_client.c
+++ b/iotc-generic-c-sdk/paho-c-impl/src/iotc_paho_client.c
@@ -90,7 +90,6 @@ int iotc_device_client_send_message(const char *message) {
     return iotc_device_client_send_message_qos(message, 1);
 }
 
-
 int iotc_device_client_send_ack_message_qos(const char* message, int qos) {
     MQTTClient_message pubmsg = MQTTClient_message_initializer;
     MQTTClient_deliveryToken token;
@@ -109,11 +108,9 @@ int iotc_device_client_send_ack_message_qos(const char* message, int qos) {
     return rc;
 }
 
-
 int iotc_device_client_send_ack_message(const char* message) {
     return iotc_device_client_send_ack_message_qos(message, 0); //change it to 1
 }
-
 
 int iotc_device_client_init(IotConnectDeviceClientConfig *c) {
     MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
@@ -134,7 +131,6 @@ int iotc_device_client_init(IotConnectDeviceClientConfig *c) {
         fprintf(stderr, "ERROR: Unable to allocate memory for paho host URL!");
         return -1;
     }
-
     char *paho_host_url = malloc(sizeof(HOST_URL_FORMAT) - 2 + strlen(c->sr->broker.host));
     if (NULL == paho_host_url) {
         fprintf(stderr,"ERROR: Unable to allocate memory for paho host URL!");

--- a/iotc-generic-c-sdk/paho-c-impl/src/iotc_paho_client.c
+++ b/iotc-generic-c-sdk/paho-c-impl/src/iotc_paho_client.c
@@ -30,6 +30,9 @@ static void paho_deinit(void) {
 }
 
 static int on_c2d_message(void *context, char *topicName, int topicLen, MQTTClient_message *message) {
+    (void) context;
+    (void) topicLen;
+
     if (c2d_msg_cb) {
         c2d_msg_cb(message->payload, message->payloadlen);
     }
@@ -39,6 +42,8 @@ static int on_c2d_message(void *context, char *topicName, int topicLen, MQTTClie
 }
 
 static void on_connection_lost(void *context, char *cause) {
+    (void) context;
+
     printf("MQTT Connection lost. Cause: %s\n", cause);
 
     if (status_cb) {

--- a/iotc-generic-c-sdk/src/iotconnect.c
+++ b/iotc-generic-c-sdk/src/iotconnect.c
@@ -80,10 +80,10 @@ static void report_sync_error(const IotclSyncResponse *response, const char *syn
 
 static IotclDiscoveryResponse *run_http_discovery(const char *cpid, const char *env) {
     IotclDiscoveryResponse *ret = NULL;
-    char* url_buff =  malloc(sizeof(HTTP_DISCOVERY_URL_FORMAT_2_1) +
-                             sizeof(IOTCONNECT_DISCOVERY_HOSTNAME) +
-                             strlen(cpid) +
-                             strlen(env) - 4 /* %s x 2 */
+    char *url_buff = malloc(sizeof(HTTP_DISCOVERY_URL_FORMAT_2_1) +
+                            sizeof(IOTCONNECT_DISCOVERY_HOSTNAME) +
+                            strlen(cpid) +
+                            strlen(env) - 4 /* %s x 2 */
     );
 
      sprintf(url_buff, HTTP_DISCOVERY_URL_FORMAT_2_1,
@@ -127,9 +127,9 @@ static IotclDiscoveryResponse *run_http_discovery(const char *cpid, const char *
 
 static IotclSyncResponse *run_http_sync(const char *cpid, const char *uniqueid) {
     IotclSyncResponse *ret = NULL;
-    char* url_buff = malloc(sizeof(HTTP_SYNC_URL_FORMAT_2_1) +
-        strlen(discovery_response->url) +
-        strlen(uniqueid)
+    char *url_buff = malloc(sizeof(HTTP_SYNC_URL_FORMAT_2_1) +
+                            strlen(discovery_response->url) +
+                            strlen(uniqueid)
     );
 
     if (!url_buff) {
@@ -257,11 +257,11 @@ static void on_message_intercept(IotclEventData data, IotConnectEventType type) 
     }
 }
 
-int iotconnect_sdk_send_packet(const char* data) {
+int iotconnect_sdk_send_packet(const char *data) {
     return iotc_device_client_send_message(data);
 }
 
-int iotconnect_sdk_send_ack_packet(const char* data) {
+int iotconnect_sdk_send_ack_packet(const char *data) {
     return iotc_device_client_send_ack_message(data);
 }
 

--- a/samples/basic-sample/main.c
+++ b/samples/basic-sample/main.c
@@ -126,6 +126,7 @@ static void publish_telemetry() {
 
     const char *str = iotcl_create_serialized_string(msg, false);
     iotcl_telemetry_destroy(msg);
+    printf("Sending: %s\n", str);
     iotconnect_sdk_send_packet(str); // underlying code will report an error
     iotcl_destroy_serialized(str);
 }
@@ -182,13 +183,13 @@ int main(int argc, char *argv[]) {
             return ret;
         }
 
-        // send 1000 messages
-        for (int i = 0; iotconnect_sdk_is_connected() && i < 1000; i++) {
+        // send 10 messages
+        for (int i = 0; iotconnect_sdk_is_connected() && i < 10; i++) {
             publish_telemetry();
-            // repeat approximately evey ~1 seconds
-            for (int k = 0; k < 1; k++) {
+            // repeat approximately evey ~5 seconds
+            for (int k = 0; k < 500; k++) {
                 iotconnect_sdk_receive();
-                usleep(1000); // 10ms
+                usleep(10000); // 10ms
             }
         }
         iotconnect_sdk_disconnect();

--- a/samples/basic-sample/main.c
+++ b/samples/basic-sample/main.c
@@ -46,17 +46,17 @@ static void command_status(IotclEventData data, bool status, const char *command
     const char *ack = iotcl_create_ack_string_and_destroy_event(data, status, message);
     printf("command: %s status=%s: %s\n", command_name, status ? "OK" : "Failed", message);
     printf("Sent CMD ack: %s\n", ack);
-    iotconnect_sdk_send_packet(ack);
+    iotconnect_sdk_send_ack_packet(ack);
     free((void *) ack);
 }
 
 static void on_command(IotclEventData data) {
     char *command = iotcl_clone_command(data);
     if (NULL != command) {
-        command_status(data, false, command, "Not implemented");
+        command_status(data, true, command, "Not implemented");
         free((void *) command);
     } else {
-        command_status(data, false, "?", "Internal error");
+        command_status(data, true, "?", "Internal error");
     }
 }
 
@@ -109,7 +109,7 @@ static void on_ota(IotclEventData data) {
     const char *ack = iotcl_create_ack_string_and_destroy_event(data, success, message);
     if (NULL != ack) {
         printf("Sent OTA ack: %s\n", ack);
-        iotconnect_sdk_send_packet(ack);
+        iotconnect_sdk_send_ack_packet(ack);
         free((void *) ack);
     }
 }
@@ -126,7 +126,6 @@ static void publish_telemetry() {
 
     const char *str = iotcl_create_serialized_string(msg, false);
     iotcl_telemetry_destroy(msg);
-    printf("Sending: %s\n", str);
     iotconnect_sdk_send_packet(str); // underlying code will report an error
     iotcl_destroy_serialized(str);
 }
@@ -183,13 +182,13 @@ int main(int argc, char *argv[]) {
             return ret;
         }
 
-        // send 10 messages
-        for (int i = 0; iotconnect_sdk_is_connected() && i < 10; i++) {
+        // send 1000 messages
+        for (int i = 0; iotconnect_sdk_is_connected() && i < 1000; i++) {
             publish_telemetry();
-            // repeat approximately evey ~5 seconds
-            for (int k = 0; k < 500; k++) {
+            // repeat approximately evey ~1 seconds
+            for (int k = 0; k < 1; k++) {
                 iotconnect_sdk_receive();
-                usleep(10000); // 10ms
+                usleep(1000); // 10ms
             }
         }
         iotconnect_sdk_disconnect();

--- a/samples/basic-sample/main.c
+++ b/samples/basic-sample/main.c
@@ -133,6 +133,9 @@ static void publish_telemetry() {
 
 
 int main(int argc, char *argv[]) {
+    (void) argc;
+    (void) argv;
+
     if (access(IOTCONNECT_SERVER_CERT, F_OK) != 0) {
         fprintf(stderr, "Unable to access IOTCONNECT_SERVER_CERT. "
                "Please change directory so that %s can be accessed from the application or update IOTCONNECT_CERT_PATH\n",


### PR DESCRIPTION
DON'T COMMIT

Review comments on iotc-generic-c-sdk-2.1

Cast to avoid comparing signed and unsigned values.
Workaround for unused arguments.
Use correct enum type/value.
