### PR TITLE
Add routines that don't require openssl for SAS key generation.

### DIFF
--- a/iotc-generic-c-sdk/src/iotc_algorithms.c
+++ b/iotc-generic-c-sdk/src/iotc_algorithms.c
@@ -4,11 +4,10 @@
 //
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <ctype.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/buffer.h>
+#include "iotconnect_common.h"
 
 #ifndef IOTHUB_RESOURCE_URI_FORMAT
 #define IOTHUB_RESOURCE_URI_FORMAT "%s/devices/%s-%s"
@@ -23,71 +22,28 @@
 #define IOTHUB_SAS_TOKEN_FORMAT "SharedAccessSignature sr=%s&sig=%s&se=%lu"
 #endif
 
-#if 1
-void hmac_sha256(const void *key, int keylen,
-                                   const unsigned char *data, int datalen,
+/*
+ * Need to supply these routines, if want to generate SAS tokens
+ */
+#define USE_OPENSSL 1
+//#define USE_ALTERNATIVE 1
+
+static void iotc_hmac_sha256(const void *key, unsigned int keylen, const unsigned char *data, unsigned int datalen, unsigned char *result, unsigned int *resultlen);
+static unsigned char *b64_string_to_buffer(const char *input, unsigned int *len);
+static char *b64_buffer_to_string(const unsigned char *input, unsigned int length);
+
+#if USE_OPENSSL
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/buffer.h>
+
+static void iotc_hmac_sha256(const void *key, unsigned int keylen,
+                                   const unsigned char *data, unsigned int datalen,
                                    unsigned char *result, unsigned int *resultlen) {
     HMAC(EVP_sha256(), key, keylen, data, datalen, result, resultlen);
 }
-#else
-void sha256_helper(const unsigned char *data1, int datalen1,
-            const unsigned char *data2, int datalen2,
-            unsigned char *result, unsigned int *resultlen) {
-	EVP_MD_CTX *c = EVP_MD_CTX_new();
 
-	EVP_DigestInit_ex(c, EVP_sha256(), NULL);
-	if(data1 != NULL && datalen1 != 0) {
-            EVP_DigestUpdate(c, data1, datalen1);
-	}
-	if(data2 != NULL && datalen2 != 0) {
-            EVP_DigestUpdate(c, data2, datalen2);
-	}
-        EVP_DigestFinal_ex(c, result, resultlen);
-	EVP_MD_CTX_free(c);
-}
-
-/*
- * This implementation of hmac_sha256 is based on the description in Wikipedia
- * https://en.wikipedia.org/wiki/HMAC
- */
-void hmac_sha256(const void *key, int keylen,
-                                   const unsigned char *data, int datalen,
-                                   unsigned char *result, unsigned int *resultlen) {
-    const int hashSize = 32;
-    const int blockSize = 64;
-    int dummySize;
-
-    unsigned char k_dash[blockSize];
-    unsigned char i_key_pad_message_hash[hashSize];
-    unsigned char output_hash[hashSize];
-
-    memset(k_dash, 0, blockSize);
-    if(keylen > blockSize) {
-	sha256_helper(key, keylen, NULL, 0, k_dash, &dummySize);
-	keylen = blockSize;
-    } else {
-        memcpy(k_dash, key, keylen);
-    }
-
-    {
-        unsigned char i_key_pad[blockSize];
-        for(int i = 0;i < blockSize;i++) {
-            i_key_pad[i] = 0x36 ^ k_dash[i];
-        }
-
-        sha256_helper(i_key_pad, blockSize, data, datalen, i_key_pad_message_hash, &dummySize);
-    }
-
-    unsigned char o_key_pad[blockSize];
-    for(int i = 0;i < blockSize;i++) {
-        o_key_pad[i] = 0x5c ^ k_dash[i];
-    }
-
-    sha256_helper(o_key_pad, blockSize, i_key_pad_message_hash, hashSize, result, resultlen);
-}
-#endif
-
-unsigned char *b64_string_to_buffer(const char *input, unsigned int *len) {
+static unsigned char *b64_string_to_buffer(const char *input, unsigned int *len) {
     BIO *b64, *source;
     size_t length = strlen(input);
 
@@ -132,9 +88,323 @@ char *b64_buffer_to_string(const unsigned char *input, unsigned int length) {
 
     return buff;
 }
+#endif // USE_OPENSSL
+
+#if USE_ALTERNATIVE
+
+//#define USE_OPENSSL_FOR_SHA_HELPER 1
+#define USE_MBEDTLS_FOR_SHA_HELPER 1
+#if defined(USE_OPENSSL_FOR_SHA_HELPER) || defined(USE_MBEDTLS_FOR_SHA_HELPER)
+static void sha256_helper(const unsigned char *data1, unsigned int datalen1, const unsigned char *data2, unsigned int datalen2, unsigned char *result, unsigned int *resultlen);
+#endif
+
+#if USE_OPENSSL_FOR_SHA_HELPER
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/buffer.h>
+
+static void sha256_helper(const unsigned char *data1, unsigned int datalen1,
+            const unsigned char *data2, unsigned int datalen2,
+            unsigned char *result, unsigned int *resultlen) {
+	EVP_MD_CTX *c = EVP_MD_CTX_new();
+
+	EVP_DigestInit_ex(c, EVP_sha256(), NULL);
+	if(data1 != NULL && datalen1 != 0) {
+            EVP_DigestUpdate(c, data1, datalen1);
+	}
+	if(data2 != NULL && datalen2 != 0) {
+            EVP_DigestUpdate(c, data2, datalen2);
+	}
+        EVP_DigestFinal_ex(c, result, resultlen);
+	EVP_MD_CTX_free(c);
+}
+#endif // USE_OPENSSL_FOR_SHA_HELPER
+
+#if USE_MBEDTLS_FOR_SHA_HELPER
+/*
+ * sha256 helper is based on https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-hashing/file/c68a6dc8d494/main.cpp/
+ */
+/*
+ *  Hello world example of using the hashing functions of mbed TLS
+ *
+ *  Copyright (C) 2016, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+//#include "mbed.h"
+#include "mbedtls/sha256.h" /* SHA-256 only */
+#include "mbedtls/md.h"     /* generic interface */
+
+#if DEBUG_LEVEL > 0
+#include "mbedtls/debug.h"
+#endif
+
+#include "mbedtls/platform.h"
+
+/*
+ * result must be preallocated 32 byte array
+ */
+static void sha256_helper(const unsigned char *data1, unsigned int datalen1,
+            const unsigned char *data2, unsigned int datalen2,
+            unsigned char *result, unsigned int *resultlen) {
+    *resultlen = 0;
+
+    mbedtls_sha256_context c;
+
+    mbedtls_sha256_init(&c);
+
+    /* 0 means SHA-256 not SHA-224 */
+    if(mbedtls_sha256_starts_ret(&c, 0) != 0)
+    {
+        IOTC_ERROR("mbedtls_sha256_starts_ret failed\n");
+        return;
+    }
+
+    if(data1 != NULL && datalen1 != 0) {
+        if(mbedtls_sha256_update_ret(&c, data1, datalen1) != 0)
+        {
+            IOTC_ERROR("mbedtls_sha256_update_ret #1 failed\n");
+            return;
+        }
+    }
+
+    if(data2 != NULL && datalen2 != 0) {
+        if(mbedtls_sha256_update_ret(&c, data2, datalen2) != 0)
+        {
+            IOTC_ERROR("mbedtls_sha256_update_ret #2 failed\n");
+            return;
+        }
+    }
+
+    if(mbedtls_sha256_finish_ret(&c, result) != 0)
+    {
+        IOTC_ERROR("mbedtls_sha256_finish_ret failed\n");
+        return;
+    }
+    *resultlen = 32;
+}
+#endif // USE_MBEDTLS_FOR_SHA_HELPER
+
+#if defined(USE_OPENSSL_FOR_SHA_HELPER) || defined(USE_MBEDTLS_FOR_SHA_HELPER)
+/*
+ * This implementation of hmac_sha256 is based on the description in Wikipedia
+ * https://en.wikipedia.org/wiki/HMAC
+ */
+static void iotc_hmac_sha256(const void *key, unsigned int keylen,
+                                   const unsigned char *data, unsigned int datalen,
+                                   unsigned char *result, unsigned int *resultlen) {
+    const int hashSize = 32;
+    const int blockSize = 64;
+    unsigned int dummySize;
+
+    unsigned char k_dash[blockSize];
+    unsigned char i_key_pad_message_hash[hashSize];
+
+    const unsigned char i_key_padding = (unsigned char) 0x36;
+    const unsigned char o_key_padding = (unsigned char) 0x5c;
+
+    memset(k_dash, 0, blockSize);
+    if(keylen > blockSize) {
+	sha256_helper(key, keylen, NULL, 0, k_dash, &dummySize);
+    } else {
+        memcpy(k_dash, key, keylen);
+    }
+
+    {
+        unsigned char i_key_pad[blockSize];
+        for(int i = 0;i < blockSize;i++) {
+            i_key_pad[i] = (unsigned char) (i_key_padding ^ k_dash[i]);
+        }
+
+        sha256_helper(i_key_pad, blockSize, data, datalen, i_key_pad_message_hash, &dummySize);
+    }
+
+    unsigned char o_key_pad[blockSize];
+    for(int i = 0;i < blockSize;i++) {
+        o_key_pad[i] = (unsigned char) (o_key_padding ^ k_dash[i]);
+    }
+
+    sha256_helper(o_key_pad, blockSize, i_key_pad_message_hash, hashSize, result, resultlen);
+}
+#else
+
+#define __must_check // needed to get crypto.h to compile
+#include "crypto.h"
+    
+static void iotc_hmac_sha256(const void *key, unsigned int keylen,
+                                   const unsigned char *data, unsigned int datalen,
+                                   unsigned char *result, unsigned int *resultlen) {
+    *resultlen = 0;
+    if(hmac_sha256(key, keylen, data, datalen, result) != 0)
+    {
+        IOTC_ERROR("hmac_sha256 failed\n");
+    }
+    *resultlen = 32;
+}
+#endif
+
+#define PADDING 255
+#define SKIP 254
+static unsigned char decode_base64_value(char c)
+{
+    if(c == '=')
+    {
+        return PADDING;
+    } 
+
+    if(c >= 'A' && c <= 'Z')
+    {
+        return (unsigned char) (c - 'A');
+    }
+    if(c >= 'a' && c <= 'z')
+    {
+        return (unsigned char) (26 + c - 'a');
+    }
+    if(c >= '0' && c <= '9')
+    {
+        return (unsigned char) (52 + c - '0');
+    }
+    if(c == '+')
+    {
+        return 62;
+    }
+    if(c == '/')
+    {
+        return 63;
+    }
+
+    return SKIP;
+}
+
+unsigned char *b64_string_to_buffer(const char *input, unsigned int *len) {
+    unsigned char read[4];
+    unsigned int input_len;
+    unsigned int max_decoded_b64_len;
+    unsigned char *decoded_b64;
+    unsigned int input_pos, to_be_decoded, output_pos;
+    unsigned char value;
+
+    *len = 0;
+
+    input_len = strlen(input);
+    max_decoded_b64_len = ((input_len + 3)/4) * 3;
+    decoded_b64 = malloc(max_decoded_b64_len + 1); // unclear if need to NULL terminate, but just in case
+    if(decoded_b64 == NULL)
+    {
+        return NULL;
+    }
+
+    for(input_pos = 0, to_be_decoded = 0, output_pos = 0;input_pos < input_len;input_pos++)
+    {
+        value = decode_base64_value(input[input_pos]);
+        if(value == SKIP)
+        {
+            continue;
+        }
+        if(value == PADDING)
+        {
+            break;
+        }
+        read[to_be_decoded++] = (unsigned char) value;
+
+        if(to_be_decoded == 4)
+        {
+            decoded_b64[output_pos + 0] = (unsigned char) ( ((read[0] & 0x3F) << 2) | ((read[1] & 0x30) >> 4) );
+            decoded_b64[output_pos + 1] = (unsigned char) ( ((read[1] & 0x0F) << 4) | ((read[2] & 0x3C) >> 2) );
+            decoded_b64[output_pos + 2] = (unsigned char) ( ((read[2] & 0x03) << 6) | (read[3] & 0x7F) );
+            output_pos += 3;
+            to_be_decoded = 0;
+        }
+    }
+
+    switch(to_be_decoded)
+    {
+        case 3:
+            // have 1 padding byte so output 2 characters
+            if(value != PADDING) { ; /* possibly an issue here - input has run out but not enough for a full decode */ }
+
+            decoded_b64[output_pos + 0] = (unsigned char) ((read[0] & 0x3F) << 2) | (unsigned char) ((read[1] & 0x30) >> 4);
+            decoded_b64[output_pos + 1] = (unsigned char) ((read[1] & 0x0F) << 4) | (unsigned char) ((read[2] & 0x3C) >> 2);
+            output_pos += 2;
+            break;
+        case 2:
+            // have (presumably) 2 padding bytes so output 1 characters
+            if(value != PADDING) { ; /* possibly an issue here - input has run out but not enough for a full decode */ }
+
+            decoded_b64[output_pos + 0] = (unsigned char) ((read[0] & 0x3F) << 2) | (unsigned char) ((read[1] & 0x30) >> 4);
+            output_pos += 1;
+            break;
+        case 1:
+            // can't have 3 padding bytes
+            break;
+        case 0: // fallthrough
+        default:
+            break;
+    }
+    decoded_b64[output_pos] = '\0'; // unclear if need to NULL terminate, but just in case
+
+    *len = output_pos;
+    return decoded_b64;
+}
+
+char *b64_buffer_to_string(const unsigned char *input, unsigned int length) {
+    unsigned char value[4];
+    char *encoded_b64;
+    unsigned int max_encoded_b64_len;
+    static const char encoding[64] = {'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
+                                      'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',
+                                      '0','1','2','3','4','5','6','7','8','9',
+                                      '+','/'};
+
+    if(length == 0)
+    {
+        return NULL;
+    }
+
+    max_encoded_b64_len = ((length+2)/3)*4;
+    encoded_b64 = malloc(max_encoded_b64_len + 1); // unclear if need to NULL terminate, but just in case
+    if(encoded_b64 == NULL)
+    {
+        return NULL;
+    }
+
+    for(unsigned int i = 0, j = 0;i < length;i += 3, j += 4)
+    {
+        unsigned char c, d, e;
+
+        c = input[i + 0];
+        d = (unsigned char) (i + 1 < length) ? input[i+1] : 0;
+        e = (unsigned char) (i + 2 < length) ? input[i+2] : 0;
+
+        value[0] = (unsigned char) (c & 0xFC) >> 2;
+        value[1] = (unsigned char) ( ((c & 0x03) << 4) | ((d & 0xF0) >> 4) );
+        value[2] = (unsigned char) ( ((d & 0x0F) << 2) | ((e & 0xC0) >> 6) );
+        value[3] = (unsigned char) (e & 0x3F);
+
+        encoded_b64[j] = encoding[value[0]];
+        encoded_b64[j+1] = encoding[value[1]];
+        encoded_b64[j+2] = (i + 1 < length) ? encoding[value[2]] : '=';
+        encoded_b64[j+3] = (i + 2 < length) ? encoding[value[3]] : '=';
+    }
+    encoded_b64[max_encoded_b64_len] = '\0'; // unclear if need to NULL terminate, but just in case
+
+    return encoded_b64;
+}
+#endif // USE_ALTERNATIVE
 
 // outbuff length should be at least ((uri_len * 3) + 1)
-char *uri_encode(const char *uri) {
+static char *uri_encode(const char *uri) {
     const size_t uri_len = strlen(uri);
     char *outbuff = malloc((uri_len * 3) + 1);
     if(!outbuff) {
@@ -157,7 +427,7 @@ char *uri_encode(const char *uri) {
     return outbuff;
 }
 
-char *gen_sas_token(const char *host, const char *cpid, const char *duid, char *b64key, time_t expiry_secs) {
+char *gen_sas_token(const char *host, const char *cpid, const char *duid, const char *b64key, unsigned long expiry_secs) {
     // example: SharedAccessSignature sr=poc-iotconnect-iothub-eu.azure-devices.net%2Fdevices%2CPID-DUUID&sig=WBBsC0rhu1idLR6aWaKiMbcrBCm9jPI4st2clhVKrW4%3D&se=1656689541
     // SharedAccessSignature sr={URL-encoded-resourceURI}&sig={signature-string}&se={expiry}
     // URL-encoded-resourceURI: myHub.azure-devices.net/devices/mydevice
@@ -168,7 +438,7 @@ char *gen_sas_token(const char *host, const char *cpid, const char *duid, char *
     const size_t len_duid = strlen(duid);
     const size_t len_resource_uri = (sizeof(IOTHUB_RESOURCE_URI_FORMAT) + len_host + len_cpid + len_duid) * 3;
 
-    const time_t expiration = time(NULL) + expiry_secs;
+    unsigned long expiration = get_expiry_from_now(expiry_secs);
     char *resource_uri = malloc(len_resource_uri);
     if(!resource_uri) {
         return NULL;
@@ -189,16 +459,15 @@ char *gen_sas_token(const char *host, const char *cpid, const char *duid, char *
     }
     sprintf(string_to_sign, IOTHUB_SIGNATURE_STR_FORMAT,
             encoded_resource_uri,
-            expiration
+            (unsigned long int) expiration
     );
 
+    unsigned int keylen = 0;
+    unsigned char *key = b64_string_to_buffer(b64key, &keylen);
 
-    unsigned int bufflen = 0;
-    unsigned char *key = b64_string_to_buffer(b64key, &bufflen);
-
-    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned char digest[32];
     unsigned int digest_len = 0;
-    hmac_sha256(key, (int) bufflen, (const unsigned char*) string_to_sign, (int) strlen(string_to_sign), digest, &digest_len);
+    iotc_hmac_sha256(key, keylen, (const unsigned char*) string_to_sign, strlen(string_to_sign), digest, &digest_len);
     free(key);
     free(string_to_sign);
 
@@ -211,19 +480,15 @@ char *gen_sas_token(const char *host, const char *cpid, const char *duid, char *
                              strlen(encoded_b64_digest) +
                              +10 /* unix time */
     );
-    if(!sas_token) {
-        free(encoded_resource_uri);
-        free(encoded_b64_digest);
-        return NULL;
+    if(sas_token) {
+        sprintf(sas_token, IOTHUB_SAS_TOKEN_FORMAT,
+                encoded_resource_uri,
+                encoded_b64_digest,
+                (unsigned long int) expiration);
     }
-    sprintf(sas_token, IOTHUB_SAS_TOKEN_FORMAT,
-            encoded_resource_uri,
-            encoded_b64_digest,
-            expiration
-    );
     free(encoded_resource_uri);
     free(encoded_b64_digest);
-    printf("Token: %s\n", sas_token);
+    IOTC_DEBUG("Token: %s\n", (sas_token) ? sas_token : "(null)");
     return sas_token;
 }
 

--- a/iotc-generic-c-sdk/src/iotconnect.c
+++ b/iotc-generic-c-sdk/src/iotconnect.c
@@ -9,6 +9,7 @@
 #ifdef IOTC_USE_PAHO
 #include "iotc_algorithms.h"
 #endif
+#include "iotconnect_common.h"
 #include "iotconnect_discovery.h"
 #include "iotconnect.h"
 #include "iotc_http_request.h"
@@ -25,57 +26,56 @@ static IotclDiscoveryResponse *discovery_response = NULL;
 static IotclSyncResponse *sync_response = NULL;
 
 // cached TPM registration ID if TPM auth is used
-// once (if) we support a discpose method, we should free this value
+// once (if) we support a dispose method, we should free this value
 static char *tpm_registration_id = NULL;
 
 static void dump_response(const char *message, IotConnectHttpResponse *response) {
-    fprintf(stderr, "%s", message);
+    IOTC_ERROR("%s", message);
     if (response->data) {
-        fprintf(stderr, " Response was:\n----\n%s\n----\n", response->data);
+        IOTC_DEBUG(" Response was:\n----\n%s\n----\n", response->data);
     } else {
-        fprintf(stderr, " Response was empty\n");
+        IOTC_WARN(" Response was empty\n");
     }
 }
 
 static void report_sync_error(const IotclSyncResponse *response, const char *sync_response_str) {
     if (NULL == response) {
-        fprintf(stderr, "Failed to obtain sync response?\n");
+        IOTC_ERROR("Failed to obtain sync response?\n");
         return;
     }
     switch (response->ds) {
         case IOTCL_SR_DEVICE_NOT_REGISTERED:
-            fprintf(stderr, "IOTC_SyncResponse error: Not registered\n");
+            IOTC_ERROR("IOTC_SyncResponse error: Not registered\n");
             break;
         case IOTCL_SR_AUTO_REGISTER:
-            fprintf(stderr, "IOTC_SyncResponse error: Auto Register\n");
+            IOTC_ERROR("IOTC_SyncResponse error: Auto Register\n");
             break;
         case IOTCL_SR_DEVICE_NOT_FOUND:
-            fprintf(stderr, "IOTC_SyncResponse error: Device not found\n");
+            IOTC_ERROR("IOTC_SyncResponse error: Device not found\n");
             break;
         case IOTCL_SR_DEVICE_INACTIVE:
-            fprintf(stderr, "IOTC_SyncResponse error: Device inactive\n");
+            IOTC_ERROR("IOTC_SyncResponse error: Device inactive\n");
             break;
         case IOTCL_SR_DEVICE_MOVED:
-            fprintf(stderr, "IOTC_SyncResponse error: Device moved\n");
+            IOTC_ERROR("IOTC_SyncResponse error: Device moved\n");
             break;
         case IOTCL_SR_CPID_NOT_FOUND:
-            fprintf(stderr, "IOTC_SyncResponse error: CPID not found\n");
+            IOTC_ERROR("IOTC_SyncResponse error: CPID not found\n");
             break;
         case IOTCL_SR_UNKNOWN_DEVICE_STATUS:
-            fprintf(stderr, "IOTC_SyncResponse error: Unknown device status error from server\n");
+            IOTC_ERROR("IOTC_SyncResponse error: Unknown device status error from server\n");
             break;
         case IOTCL_SR_ALLOCATION_ERROR:
-            fprintf(stderr, "IOTC_SyncResponse internal error: Allocation Error\n");
+            IOTC_ERROR("IOTC_SyncResponse internal error: Allocation Error\n");
             break;
         case IOTCL_SR_PARSING_ERROR:
-            fprintf(stderr,
-                    "IOTC_SyncResponse internal error: Parsing error. Please check parameters passed to the request.\n");
+            IOTC_ERROR("IOTC_SyncResponse internal error: Parsing error. Please check parameters passed to the request.\n");
             break;
         default:
-            fprintf(stderr, "WARN: report_sync_error called, but no error returned?\n");
+            IOTC_ERROR("WARN: report_sync_error called, but no error returned?\n");
             break;
     }
-    fprintf(stderr, "Raw server response was:\n--------------\n%s\n--------------\n", sync_response_str);
+    IOTC_ERROR("Raw server response was:\n--------------\n%s\n--------------\n", sync_response_str);
 }
 
 static IotclDiscoveryResponse *run_http_discovery(const char *cpid, const char *env) {
@@ -87,7 +87,7 @@ static IotclDiscoveryResponse *run_http_discovery(const char *cpid, const char *
     );
 
     if(!url_buff) {
-        fprintf(stderr, "Unable to allocate memory");
+        IOTC_ERROR("Unable to allocate memory");
         return NULL;
     }
 
@@ -112,12 +112,16 @@ static IotclDiscoveryResponse *run_http_discovery(const char *cpid, const char *
     }
     if (json_start != response.data) {
         dump_response("WARN: Expected JSON to start immediately in the returned data.", &response);
+    } else {
+        dump_response("discovery reponse ok before parsing", &response);
     }
 
     ret = iotcl_discovery_parse_discovery_response(json_start);
     if (!ret) {
-        fprintf(stderr, "Error: Unable to get discovery response for environment \"%s\". Please check the environment name in the key vault.\n", env);
+        IOTC_ERROR("Error: Unable to get discovery response for environment \"%s\". Please check the environment name in the key vault.\n", env);
     }
+
+    dump_response("discovery reponse parsing is ok", &response);
 
     cleanup:
     free(url_buff);
@@ -135,7 +139,7 @@ static IotclSyncResponse *run_http_sync(const char *cpid, const char *uniqueid) 
     char *post_data = malloc(IOTCONNECT_DISCOVERY_PROTOCOL_POST_DATA_MAX_LEN + 1);
 
     if (!url_buff || !post_data) {
-        fprintf(stderr, "run_http_sync: Out of memory!");
+        IOTC_ERROR("run_http_sync: Out of memory!");
         free(url_buff); // one of them could have succeeded
         free(post_data);
         return NULL;
@@ -173,6 +177,9 @@ static IotclSyncResponse *run_http_sync(const char *cpid, const char *uniqueid) 
     if (json_start != response.data) {
         dump_response("WARN: Expected JSON to start immediately in the returned data.", &response);
     }
+    else {
+        dump_response("sync reponse parsing is ok", &response);
+    }
 
     ret = iotcl_discovery_parse_sync_response(json_start);
     if (!ret || ret->ds != IOTCL_SR_OK) {
@@ -185,7 +192,7 @@ static IotclSyncResponse *run_http_sync(const char *cpid, const char *uniqueid) 
             }
 
             sprintf(ret->broker.client_id, "%s-%s", cpid, uniqueid);
-            printf("TPM Device is not yet enrolled. Enrolling...\n");
+            IOTC_WARN("TPM Device is not yet enrolled. Enrolling...\n");
         } else {
             report_sync_error(ret, response.data);
             iotcl_discovery_free_sync_response(ret);
@@ -203,23 +210,23 @@ static IotclSyncResponse *run_http_sync(const char *cpid, const char *uniqueid) 
 static void on_mqtt_c2d_message(const unsigned char *message, size_t message_len) {
     char *str = malloc(message_len + 1);
     if(!str) {
-        fprintf(stderr, "Unable to allocate memory\n");
+        IOTC_ERROR("Unable to allocate memory\n");
         return;
     }
 
     memcpy(str, message, message_len);
     str[message_len] = 0;
-    printf("event>>> %s\n", str);
+    IOTC_DEBUG("event>>> %s\n", str);
     if (!iotcl_process_event(str)) {
-        fprintf(stderr, "Error encountered while processing %s\n", str);
+        IOTC_ERROR("Error encountered while processing %s\n", str);
     }
     free(str);
 }
 
 void iotconnect_sdk_disconnect(void) {
-    printf("Disconnecting...\n");
+    IOTC_DEBUG("Disconnecting...\n");
     if (0 == iotc_device_client_disconnect()) {
-        printf("Disconnected.\n");
+        IOTC_DEBUG("Disconnected.\n");
     }
 }
 
@@ -241,20 +248,20 @@ static void on_message_intercept(IotclEventData data, IotConnectEventType type) 
             sync_response = NULL;
             discovery_response = run_http_discovery(config.cpid, config.env);
             if (NULL == discovery_response) {
-                fprintf(stderr, "Unable to run HTTP discovery on ON_FORCE_SYNC\n");
+                IOTC_ERROR("Unable to run HTTP discovery on ON_FORCE_SYNC\n");
                 return;
             }
             sync_response = run_http_sync(config.cpid, config.duid);
             if (NULL == sync_response) {
-                fprintf(stderr, "Unable to run HTTP sync on ON_FORCE_SYNC\n");
+                IOTC_ERROR("Unable to run HTTP sync on ON_FORCE_SYNC\n");
                 return;
             }
-            printf("Got ON_FORCE_SYNC. Disconnecting.\n");
+            IOTC_DEBUG("Got ON_FORCE_SYNC. Disconnecting.\n");
             iotconnect_sdk_disconnect(); // client will get notification that we disconnected and will reinit
             break;
 
         case ON_CLOSE:
-            printf("Got ON_CLOSE. Closing the mqtt connection. Device restart is required.\n");
+            IOTC_DEBUG("Got ON_CLOSE. Closing the mqtt connection. Device restart is required.\n");
             iotconnect_sdk_disconnect();
             break;
 
@@ -278,7 +285,7 @@ void iotconnect_sdk_receive(void) {
 ///////////////////////////////////////////////////////////////////////////////////
 // this the Initialization os IoTConnect SDK
 int iotconnect_sdk_init(void) {
-    int ret;
+    int ret = 0;
 
     if (config.auth_info.type == IOTC_AT_TPM) {
         if (!config.duid || strlen(config.duid) == 0) {
@@ -295,7 +302,7 @@ int iotconnect_sdk_init(void) {
             // get_base_url will print the error
             return -1;
         }
-        printf("Discovery response parsing successful.\n");
+        IOTC_DEBUG("Discovery response parsing successful.\n");
     }
 
     if (!sync_response) {
@@ -304,7 +311,7 @@ int iotconnect_sdk_init(void) {
             // Sync_call will print the error
             return -2;
         }
-        printf("Sync response parsing successful.\n");
+        IOTC_DEBUG("Sync response parsing successful.\n");
     }
 
     // We want to print only first 4 characters of cpid
@@ -313,7 +320,7 @@ int iotconnect_sdk_init(void) {
     lib_config.device.duid = config.duid;
 
     if (!config.env || !config.cpid || !config.duid) {
-        printf("Error: Device configuration is invalid. Configuration values for env, cpid and duid are required.\n");
+        IOTC_ERROR("Error: Device configuration is invalid. Configuration values for env, cpid and duid are required.\n");
         return -1;
     }
 
@@ -326,8 +333,8 @@ int iotconnect_sdk_init(void) {
     char cpid_buff[5];
     strncpy(cpid_buff, config.cpid, 4);
     cpid_buff[4] = 0;
-    printf("CPID: %s***\n", cpid_buff);
-    printf("ENV:  %s\n", config.env);
+    IOTC_DEBUG("CPID: %s***\n", cpid_buff);
+    IOTC_DEBUG("ENV:  %s\n", config.env);
 
 
     if (config.auth_info.type != IOTC_AT_TOKEN &&
@@ -335,63 +342,72 @@ int iotconnect_sdk_init(void) {
         config.auth_info.type != IOTC_AT_TPM &&
         config.auth_info.type != IOTC_AT_SYMMETRIC_KEY
         ) {
-        fprintf(stderr, "Error: Unsupported authentication type!\n");
+        IOTC_ERROR("Error: Unsupported authentication type!\n");
         return -1;
     }
 
     if (!config.auth_info.trust_store) {
-        fprintf(stderr, "Error: Configuration server certificate is required.\n");
+        IOTC_ERROR("Error: Configuration server certificate is required.\n");
         return -1;
     }
     if (config.auth_info.type == IOTC_AT_X509 && (
             !config.auth_info.data.cert_info.device_cert ||
             !config.auth_info.data.cert_info.device_key)) {
-        fprintf(stderr, "Error: Configuration authentication info is invalid.\n");
+        IOTC_ERROR("Error: Configuration authentication info is invalid.\n");
         return -1;
     }
 
     if (config.auth_info.type == IOTC_AT_SYMMETRIC_KEY) {
         if (config.auth_info.data.symmetric_key && strlen(config.auth_info.data.symmetric_key) > 0) {
 #ifdef IOTC_USE_PAHO
-            // for paho we need to pass the generated sas token
+            // for paho and mosquitto we need to pass the generated sas token
             char *sas_token = gen_sas_token(sync_response->broker.host,
                                                   config.cpid,
                                                   config.duid,
                                                   config.auth_info.data.symmetric_key,
                                                   60
             );
-            free (sync_response->broker.pass);
+	
+	    if(sas_token == NULL) {
+                IOTC_ERROR("gen_sas_token returns NULL\n");
+	    }
+	
+	    if(sync_response->broker.pass) {
+                free (sync_response->broker.pass);
+	    }
             // a bit of a hack - the token will be freed when freeing the sync response
-            // paho will use the borken pasword
+            // paho will use the SAS token as the broker password
             sync_response->broker.pass = sas_token;
 #endif
         } else {
-            fprintf(stderr, "Error: Configuration symmetric key is missing.\n");
+            IOTC_ERROR("Error: Configuration symmetric key is missing.\n");
             return -1;
         }
     }
 
     if (config.auth_info.type == IOTC_AT_TOKEN) {
         if (!(sync_response->broker.pass || strlen(config.auth_info.data.symmetric_key) == 0)) {
-            fprintf(stderr, "Error: Unable to obtainm .\n");
+            IOTC_ERROR("Error: Unable to obtainm .\n");
             return -1;
         }
     }
     if (!iotcl_init(&lib_config)) {
-        fprintf(stderr, "Error: Failed to initialize the IoTConnect Lib\n");
+        IOTC_ERROR("Error: Failed to initialize the IoTConnect Lib\n");
         return -1;
     }
 
     IotConnectDeviceClientConfig pc;
+    memset(&pc, 0, sizeof(pc));
+
     pc.sr = sync_response;
     pc.qos = config.qos;
     pc.status_cb = config.status_cb;
-    pc.c2d_msg_cb = &on_mqtt_c2d_message;
+    pc.c2d_msg_cb = on_mqtt_c2d_message;
     pc.auth = &config.auth_info;
 
     ret = iotc_device_client_init(&pc);
     if (ret) {
-        fprintf(stderr, "Failed to connect!\n");
+        IOTC_ERROR("Failed to connect!\n");
         return ret;
     }
 
@@ -405,7 +421,7 @@ int iotconnect_sdk_init(void) {
             return -2;
         }
         lib_config.telemetry.dtg = sync_response->dtg;
-        printf("Secondary Sync response parsing successful. DTG is: %s.\n", sync_response->dtg);
+        IOTC_DEBUG("Secondary Sync response parsing successful. DTG is: %s.\n", sync_response->dtg);
     }
 
     return ret;

--- a/samples/basic-sample/main.c
+++ b/samples/basic-sample/main.c
@@ -16,13 +16,16 @@
 #define F_OK 0
 #include <Windows.h>
 #include <io.h>
-int usleep(unsigned long usec) {
+int iotc_usleep(unsigned long usec) {
     Sleep(usec / 1000);
     return 0;
 }
 #define access    _access_s
 #else
 #include <unistd.h>
+static int iotc_usleep(unsigned long usec) {
+    return usleep(usec);
+}
 #endif
 
 #define APP_VERSION "00.01.00"
@@ -31,21 +34,21 @@ static void on_connection_status(IotConnectConnectionStatus status) {
     // Add your own status handling
     switch (status) {
         case IOTC_CS_MQTT_CONNECTED:
-            printf("IoTConnect Client Connected\n");
+            IOTC_DEBUG("IoTConnect Client Connected\n");
             break;
         case IOTC_CS_MQTT_DISCONNECTED:
-            printf("IoTConnect Client Disconnected\n");
+            IOTC_DEBUG("IoTConnect Client Disconnected\n");
             break;
         default:
-            printf("IoTConnect Client ERROR\n");
+            IOTC_DEBUG("IoTConnect Client ERROR\n");
             break;
     }
 }
 
 static void command_status(IotclEventData data, bool status, const char *command_name, const char *message) {
     const char *ack = iotcl_create_ack_string_and_destroy_event(data, status, message);
-    printf("command: %s status=%s: %s\n", command_name, status ? "OK" : "Failed", message);
-    printf("Sent CMD ack: %s\n", ack);
+    IOTC_DEBUG("command: %s status=%s: %s\n", command_name, status ? "OK" : "Failed", message);
+    IOTC_DEBUG("Sent CMD ack: %s\n", ack);
     iotconnect_sdk_send_packet(ack);
     free((void *) ack);
 }
@@ -73,18 +76,18 @@ static void on_ota(IotclEventData data) {
     char *url = iotcl_clone_download_url(data, 0);
     bool success = false;
     if (NULL != url) {
-        printf("Download URL is: %s\n", url);
+        IOTC_DEBUG("Download URL is: %s\n", url);
         const char *version = iotcl_clone_sw_version(data);
         if (is_app_version_same_as_ota(version)) {
-            printf("OTA request for same version %s. Sending success\n", version);
+            IOTC_DEBUG("OTA request for same version %s. Sending success\n", version);
             success = true;
             message = "Version is matching";
         } else if (app_needs_ota_update(version)) {
-            printf("OTA update is required for version %s.\n", version);
+            IOTC_DEBUG("OTA update is required for version %s.\n", version);
             success = false;
             message = "Not implemented";
         } else {
-            printf("Device firmware version %s is newer than OTA version %s. Sending failure\n", APP_VERSION,
+            IOTC_DEBUG("Device firmware version %s is newer than OTA version %s. Sending failure\n", APP_VERSION,
                    version);
             // Not sure what to do here. The app version is better than OTA version.
             // Probably a development version, so return failure?
@@ -101,14 +104,14 @@ static void on_ota(IotclEventData data) {
         const char *command = iotcl_clone_command(data);
         if (NULL != command) {
             // URL will be inside the command
-            printf("Command is: %s\n", command);
+            IOTC_DEBUG("Command is: %s\n", command);
             message = "Old back end URLS are not supported by the app";
             free((void *) command);
         }
     }
     const char *ack = iotcl_create_ack_string_and_destroy_event(data, success, message);
     if (NULL != ack) {
-        printf("Sent OTA ack: %s\n", ack);
+        IOTC_DEBUG("Sent OTA ack: %s\n", ack);
         iotconnect_sdk_send_packet(ack);
         free((void *) ack);
     }
@@ -116,25 +119,66 @@ static void on_ota(IotclEventData data) {
 
 
 static void publish_telemetry() {
-    IotclMessageHandle msg = iotcl_telemetry_create();
+    IotclMessageHandle msg = NULL;
+    const char *str = NULL;
+    const char *timestamp = NULL;
+
+    msg = iotcl_telemetry_create();
+    if(msg == NULL) {
+        IOTC_ERROR("iotcl_telemetry_create() failed\n");
+        goto cleanup;
+    }
 
     // Optional. The first time you create a data point, the current timestamp will be automatically added
     // TelemetryAddWith* calls are only required if sending multiple data points in one packet.
-    iotcl_telemetry_add_with_iso_time(msg, iotcl_iso_timestamp_now());
-    iotcl_telemetry_set_string(msg, "version", APP_VERSION);
-    iotcl_telemetry_set_number(msg, "cpu", 3.123); // test floating point numbers
+    timestamp = iotcl_iso_timestamp_now();
+    if(timestamp == NULL) {
+        IOTC_ERROR("iotcl_iso_timestamp_now() failed\n");
+        goto cleanup;
+    }
 
-    const char *str = iotcl_create_serialized_string(msg, false);
+    if(iotcl_telemetry_add_with_iso_time(msg, timestamp) == false) {
+        IOTC_ERROR("iotcl_telemetry_add_with_iso_time() failed\n");
+        goto cleanup;
+    }
+
+    if(iotcl_telemetry_set_string(msg, "version", APP_VERSION) == false) {
+        IOTC_ERROR("iotcl_telemetry_set_string() failed\n");
+        goto cleanup;
+    }
+
+    // test floating point numbers
+    if(iotcl_telemetry_set_number(msg, "cpu", 3.123) == false) {
+        IOTC_ERROR("iotcl_telemetry_set_number() failed\n");
+        goto cleanup;
+    }
+
+    str = iotcl_create_serialized_string(msg, false);
+    if(str == NULL) {
+        IOTC_ERROR("iotcl_create_serialized_string() failed\n");
+        goto cleanup;
+    }
+
+    // partial cleanup
     iotcl_telemetry_destroy(msg);
-    printf("Sending: %s\n", str);
+    msg = NULL;
+
+    IOTC_DEBUG("Sending: %s\n", str);
     iotconnect_sdk_send_packet(str); // underlying code will report an error
-    iotcl_destroy_serialized(str);
+cleanup:
+    if(msg) {
+        iotcl_telemetry_destroy(msg);
+    }
+
+    if(str) {
+        iotcl_destroy_serialized(str);
+    }
 }
 
 
 int main(int argc, char *argv[]) {
     if (access(IOTCONNECT_SERVER_CERT, F_OK) != 0) {
-        fprintf(stderr, "Unable to access IOTCONNECT_SERVER_CERT. "
+        IOTC_ERROR("Unable to access IOTCONNECT_SERVER_CERT. "
                "Please change directory so that %s can be accessed from the application or update IOTCONNECT_CERT_PATH\n",
                IOTCONNECT_SERVER_CERT);
     }
@@ -143,13 +187,15 @@ int main(int argc, char *argv[]) {
         if (access(IOTCONNECT_IDENTITY_CERT, F_OK) != 0 ||
             access(IOTCONNECT_IDENTITY_KEY, F_OK) != 0
                 ) {
-            fprintf(stderr, "Unable to access device identity private key and certificate. "
+            IOTC_ERROR("Unable to access device identity private key and certificate. "
                    "Please change directory so that %s can be accessed from the application or update IOTCONNECT_CERT_PATH\n",
                    IOTCONNECT_SERVER_CERT);
         }
     }
 
     IotConnectClientConfig *config = iotconnect_sdk_init_and_get_config();
+    memset(config, 0, sizeof(*config));
+
     config->cpid = IOTCONNECT_CPID;
     config->env = IOTCONNECT_ENV;
     config->duid = IOTCONNECT_DUID;
@@ -163,9 +209,11 @@ int main(int argc, char *argv[]) {
         config->auth_info.data.scope_id = IOTCONNECT_SCOPE_ID;
     } else if (config->auth_info.type == IOTC_AT_SYMMETRIC_KEY){
         config->auth_info.data.symmetric_key = IOTCONNECT_SYMMETRIC_KEY;
-    } else if (config->auth_info.type != IOTC_AT_TOKEN) { // token type does not need any secret or info
+    } else if (config->auth_info.type == IOTC_AT_TOKEN) {
+        // token type does not need any secret or info
+    } else {
         // none of the above
-        fprintf(stderr, "IOTCONNECT_AUTH_TYPE is invalid\n");
+        IOTC_ERROR("IOTCONNECT_AUTH_TYPE is invalid\n");
         return -1;
     }
 
@@ -179,21 +227,29 @@ int main(int argc, char *argv[]) {
     for (int j = 0; j < 10; j++) {
         int ret = iotconnect_sdk_init();
         if (0 != ret) {
-            fprintf(stderr, "IoTConnect exited with error code %d\n", ret);
+            IOTC_ERROR("IoTConnect exited with error code %d\n", ret);
             return ret;
         }
+        IOTC_DEBUG("iotconnect_sdk_init() %d\n", j);
 
         // send 10 messages
-        for (int i = 0; iotconnect_sdk_is_connected() && i < 10; i++) {
+        for (int i = 0; i < 10; i++) {
+            if  (!iotconnect_sdk_is_connected()) {
+                IOTC_ERROR("iotconnect_sdk_is_connected() returned false\n");
+                break;
+            }
+
             publish_telemetry();
             // repeat approximately evey ~5 seconds
             for (int k = 0; k < 500; k++) {
                 iotconnect_sdk_receive();
-                usleep(10000); // 10ms
+                iotc_usleep(10000); // 10ms
             }
         }
+
         iotconnect_sdk_disconnect();
     }
 
+    IOTC_DEBUG("exiting basic_sample()\n" );
     return 0;
 }


### PR DESCRIPTION
Use an error/warn/debug mechanism (needs iotc-c-lib modification) rather than using printf, etc. Fix crashes when cJSON fails (due to issue with floating-point output).