### PR TITLE
Add an explicit enum value for self-signed certificates

### DIFF
--- a/iotc-generic-c-sdk/azure-sdk-impl/src/azure_sdk_client.c
+++ b/iotc-generic-c-sdk/azure-sdk-impl/src/azure_sdk_client.c
@@ -337,7 +337,8 @@ int iotc_device_client_init(IotConnectDeviceClientConfig *c) {
             );
             break;
 
-        case IOTC_AT_X509:
+        case IOTC_AT_X509: /* fallthrough */
+        case IOTC_AT_SELF_SIGNED:
             connection_string_buffer = malloc(sizeof(IOTC_CONNECTION_STRING_FORMAT_X509)
                                               + strlen(c->sr->broker.host)
                                               + strlen(c->sr->broker.client_id)
@@ -389,7 +390,7 @@ int iotc_device_client_init(IotConnectDeviceClientConfig *c) {
         return -1;
     }
 
-    if (c->auth->type == IOTC_AT_X509) {
+    if (c->auth->type == IOTC_AT_X509 || c->auth->type == IOTC_AT_SELF_SIGNED) {
         char *device_cert = file_to_string(c->auth->data.cert_info.device_cert);
         char *device_key = file_to_string(c->auth->data.cert_info.device_key);
         if (

--- a/iotc-generic-c-sdk/include/iotconnect.h
+++ b/iotc-generic-c-sdk/include/iotconnect.h
@@ -22,8 +22,11 @@ typedef enum {
     // and must not be used in production
     IOTC_AT_TOKEN = 1,
 
-    // CA Cert and Self Signed Cert
+    // CA Cert
     IOTC_AT_X509 = 2,
+
+    // Self Signed Cert
+    IOTC_AT_SELF_SIGNED = 3, // 3 for compatibility with sync
 
     // TPM hardware devices
     IOTC_AT_TPM = 4, // 4 for compatibility with sync

--- a/iotc-generic-c-sdk/paho-c-impl/src/iotc_paho_client.c
+++ b/iotc-generic-c-sdk/paho-c-impl/src/iotc_paho_client.c
@@ -123,7 +123,7 @@ int iotc_device_client_init(IotConnectDeviceClientConfig *c) {
 
     ssl_opts.verify = 1;
     ssl_opts.trustStore = c->auth->trust_store;
-    if (c->auth->type == IOTC_AT_X509) {
+    if (c->auth->type == IOTC_AT_X509 || c->auth->type == IOTC_AT_SELF_SIGNED) {
         ssl_opts.keyStore = c->auth->data.cert_info.device_cert;
         ssl_opts.privateKey = c->auth->data.cert_info.device_key;
     }

--- a/iotc-generic-c-sdk/src/iotconnect.c
+++ b/iotc-generic-c-sdk/src/iotconnect.c
@@ -332,6 +332,7 @@ int iotconnect_sdk_init(void) {
 
     if (config.auth_info.type != IOTC_AT_TOKEN &&
         config.auth_info.type != IOTC_AT_X509 &&
+        config.auth_info.type != IOTC_AT_SELF_SIGNED &&
         config.auth_info.type != IOTC_AT_TPM &&
         config.auth_info.type != IOTC_AT_SYMMETRIC_KEY
         ) {
@@ -343,7 +344,7 @@ int iotconnect_sdk_init(void) {
         fprintf(stderr, "Error: Configuration server certificate is required.\n");
         return -1;
     }
-    if (config.auth_info.type == IOTC_AT_X509 && (
+    if ((config.auth_info.type == IOTC_AT_X509 || config.auth_info.type == IOTC_AT_SELF_SIGNED) && (
             !config.auth_info.data.cert_info.device_cert ||
             !config.auth_info.data.cert_info.device_key)) {
         fprintf(stderr, "Error: Configuration authentication info is invalid.\n");

--- a/samples/basic-sample/main.c
+++ b/samples/basic-sample/main.c
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
                IOTCONNECT_SERVER_CERT);
     }
 
-    if (IOTCONNECT_AUTH_TYPE == IOTC_AT_X509) {
+    if (IOTCONNECT_AUTH_TYPE == IOTC_AT_X509 || IOTCONNECT_AUTH_TYPE == IOTC_AT_SELF_SIGNED) {
         if (access(IOTCONNECT_IDENTITY_CERT, F_OK) != 0 ||
             access(IOTCONNECT_IDENTITY_KEY, F_OK) != 0
                 ) {
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
     config->auth_info.type = IOTCONNECT_AUTH_TYPE;
     config->auth_info.trust_store = IOTCONNECT_SERVER_CERT;
 
-    if (config->auth_info.type == IOTC_AT_X509) {
+    if (config->auth_info.type == IOTC_AT_X509 || IOTCONNECT_AUTH_TYPE == IOTC_AT_SELF_SIGNED) {
         config->auth_info.data.cert_info.device_cert = IOTCONNECT_IDENTITY_CERT;
         config->auth_info.data.cert_info.device_key = IOTCONNECT_IDENTITY_KEY;
     } else if (config->auth_info.type == IOTC_AT_TPM) {


### PR DESCRIPTION
Add an explicit enum so that the auth type enum in C code matches "at" value in discovery/sync - for consistency.