### PR TITLE
iotconnect_sdk_deinit should not be called from iotconnect_sdk_connect

### DIFF
--- a/iotc-generic-c-sdk/src/iotconnect.c
+++ b/iotc-generic-c-sdk/src/iotconnect.c
@@ -271,7 +271,6 @@ int iotconnect_sdk_connect(void) {
     int status = iotc_device_client_connect(&dc);
     if (status) {
         IOTC_ERROR("Failed to connect!");
-        iotconnect_sdk_deinit();
         return status;
     }
     return 0;


### PR DESCRIPTION
when calling, iotconnect_sdk_connect() and it fails, it should not iotconnect_sdk_deinit().